### PR TITLE
o-form: add not registered attributes to getAttributesToQuery

### DIFF
--- a/ontimize/components/form/o-form.component.ts
+++ b/ontimize/components/form/o-form.component.ts
@@ -869,6 +869,8 @@ export class OFormComponent implements OnInit, OnDestroy {
       });
     }
 
+	attributes = attributes.concat(this.colsArray.filter(col => attributes.indexOf(col) < 0));
+
     return attributes;
   }
 

--- a/ontimize/components/form/o-form.component.ts
+++ b/ontimize/components/form/o-form.component.ts
@@ -869,7 +869,6 @@ export class OFormComponent implements OnInit, OnDestroy {
       });
     }
 
-	
 	attributes = attributes.concat(this.colsArray.filter(col => attributes.indexOf(col) < 0));
 
     return attributes;

--- a/ontimize/components/form/o-form.component.ts
+++ b/ontimize/components/form/o-form.component.ts
@@ -869,6 +869,7 @@ export class OFormComponent implements OnInit, OnDestroy {
       });
     }
 
+	
 	attributes = attributes.concat(this.colsArray.filter(col => attributes.indexOf(col) < 0));
 
     return attributes;


### PR DESCRIPTION
Using 'columns' attribute from o-form in order to query attributes which are not resitered through a component in the form.